### PR TITLE
#15662525 report test coverage locally with jacoco

### DIFF
--- a/app/src/main/res/layout/content_detail_view.xml
+++ b/app/src/main/res/layout/content_detail_view.xml
@@ -11,7 +11,7 @@
     <android.support.v4.widget.SwipeRefreshLayout
         android:id="@+id/detail_view_refresh_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="match_parent">
 
     <ScrollView
         android:layout_width="match_parent"

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.0'
         classpath 'org.jacoco:org.jacoco.core:0.8.2'
         
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Jan 15 21:46:58 WAT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/tools/jacoco-test-cov.gradle
+++ b/tools/jacoco-test-cov.gradle
@@ -1,4 +1,4 @@
-task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'connectedDebugAndroidTest']) {
     reports {
         xml.enabled = true
         html.enabled = true
@@ -12,22 +12,15 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'crea
             '**/*$ViewBinder*.*',
             '**/*/Test*.*',
             'android/**/*.*',
-            'android/*.*',
-            'android/**/**/**/*.*',
-            'de.hdodenhof.circleimageview/R.class',
-            'com.**',
-            '**/*$*$*.*'
+            'de.hdodenhof.circleimageview/R.class'
     ]
-    def debugTree = fileTree(
-            dir: "$project.buildDir/intermediates/app_classes/debug/",
-            excludes: fileFilter
-    )
+    def debugTree = fileTree(dir: "${project.buildDir}/intermediates/javac/debug/compileDebugJavaWithJavac/classes", excludes: fileFilter)
     def mainSrc = "$project.projectDir/app/src/main/java"
 
     sourceDirectories = files([mainSrc])
     classDirectories = files([debugTree])
     executionData = fileTree(dir: project.buildDir, includes: [
             'jacoco/testDebugUnitTest.exec',
-            'outputs/code-coverage/connected/**/*.ec'
+            'outputs/code_coverage/debugAndroidTest/connected/**/*.ec'
     ])
 }


### PR DESCRIPTION
#### What does this PR do?
- Report test coverage locally with jacoco

#### Description of tasks to be completed
- upgrade gradle and and android plugins
- point jacoco to the correct directory source for classes
- point jacoco to the correct directory source for executable coverage outputs for AndroidTest

#### How should this be manually tested?
- Clone this `repo`
- Checkout into `ch-report-coverage-locally-15662525`
- Open the project with **Android Studio**
- Run `./gradlew clean build jacocoTestReport`
- Expect a **Successful Build**
- Go to `app/build/reports/jacoco/jacocoTestReport/html/index.html` and open in a browser
- Expect to see `test coverage report`

#### Relevant Pivotal Tracker stories
15662525